### PR TITLE
Added quotes to title

### DIFF
--- a/_posts/2015-07-27-July-Event.md
+++ b/_posts/2015-07-27-July-Event.md
@@ -1,7 +1,7 @@
 ---
 layout: event
 category: event
-title: MaptimeATL Instructional Night: Anatomy of a Web Map
+title: "MaptimeATL Instructional Night: Anatomy of a Web Map"
 rsvp: http://www.meetup.com/MaptimeATL/events/223439779/
 ---
 


### PR DESCRIPTION
If it includes a colon, the title won't display correctly without
quotes.
